### PR TITLE
perf: use `findfirst` for efficient searching

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -175,9 +175,10 @@ end
 Base.show(io::IO, a::Annotations) = print(io, "Annotations $(atype) on $(recid)")
 
 function _annofile(adb::ADB, recid, atype)
-  dts = adb.rec[adb.rec.recid .== recid, :dts]
-  length(dts) != 1 && throw(ArgumentError("No such recording"))
-  s = Dates.format(first(dts), "yyyymmdd")
+  index = findfirst(isequal(recid), adb.rec.recid)
+  isnothing(index) && throw(ArgumentError("No such recording"))
+  dts = adb.rec[index, :dts]
+  s = Dates.format(dts, "yyyymmdd")
   atype === nothing && return joinpath(adb.root, "annotations", s, "$(recid)-")
   joinpath(adb.root, "annotations", s, "$(recid)-$(atype).csv")
 end


### PR DESCRIPTION
The current implementation of function `_annofile` is slow when the number of `adb.rec.recid` is large. With this change, a speed-up by a factor of ~3 can be achieved.
```julia
using AcousticAnnotations, Dates, BenchmarkTools

root = "/home/ymtoo/Projects/reefwatch-db"
recroot = "/path/to/acoustic/recordings"
adb = ADB(root; create=false, recroot=recroot)
@btime annotations(adb, "psd"; location="RL-W", from=DateTime(2019,7,1,0,0,0), to=DateTime(2019,8,1,0,0,0))
# old: 18.466 s (4361575 allocations: 460.37 MiB)
# new: 6.722 s (4336633 allocations: 269.76 MiB)
```