### PR TITLE
Improve annotations

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,7 +98,7 @@ end
   @test a[2,:start] == 2.0
   @test a[2,:duration] == 1.2
   @test a[2,:remark] == "works too!"
-  @test a[2,:newcol] === "new column"
+  @test a[2,:newcol] == "new column"
   @test length(annotationtypes(adb)) == 1
   @test length(annotationtypes(adb, id1)) == 1
   @test length(annotationtypes(adb, id2)) == 0


### PR DESCRIPTION
This patch avoids redundant datetime search in `_annofile(adb::ADB, recid, atype)`. If the corresponding datetime is known, we can use `_annofile(adb::ADB, dts::DateTime, recid, atype)` to get the filename. For a large ADB (~400000 recordings), a speed-up by a factor of ~7 can be achieved.